### PR TITLE
fix: Pass ALWAYS_COLLABORATORS secret to workflow and improve logging

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -51,19 +51,13 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
-        locally-enabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        eq-without-hash,
         import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -470,4 +464,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -31,10 +31,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
@@ -55,15 +51,9 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
+disable=long-suffix,
         old-ne-operator,
         old-octal-literal,
-        import-star-module-level,
         non-ascii-bytes-literal,
         raw-checker-failed,
         bad-inline-option,
@@ -73,61 +63,7 @@ disable=print-statement,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
         eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
         import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -414,13 +350,6 @@ max-line-length=100
 
 # Maximum number of lines in a module
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/.github/workflows/update_repo_settings.yml
+++ b/.github/workflows/update_repo_settings.yml
@@ -31,5 +31,6 @@ jobs:
     - name: "Update Repos"
       env:
         SOURCE_PUSH_TOKEN: ${{ secrets.SOURCE_PUSH_TOKEN }}
+        ALWAYS_COLLABORATORS: ${{ secrets.ALWAYS_COLLABORATORS }}
       run: |-
         python update_repos.py

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,2 @@
+---
+extends: .github/linters/.markdown-lint.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,20 @@
+---
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 160
+  truthy:
+    allowed-values: ["true", "false", "on"]
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  comments: disable
+  comments-indentation: disable
+  trailing-spaces: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# Changelog
-
+﻿# Changelog
 All notable changes to this project will be documented in this file.
 
 <!--
@@ -7,9 +6,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
-
 ### Added
-
 ### Fixed
 
 - Pass ALWAYS_COLLABORATORS secret to workflow so collaborator invites are actually sent
@@ -17,13 +14,10 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 - Fixed obsolete pylint options in super-linter config that caused lint-code check to fail
 
 ### Changed
-
 ### Removed
-
 ### Deployment Changes
 
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->
-
 ## [0.0.0] - Project created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-﻿# Changelog
+# Changelog
+
 All notable changes to this project will be documented in this file.
 
 <!--
@@ -6,13 +7,23 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
+
 ### Added
+
 ### Fixed
+
+- Pass ALWAYS_COLLABORATORS secret to workflow so collaborator invites are actually sent
+- Improved logging for collaborator invite step
+- Fixed obsolete pylint options in super-linter config that caused lint-code check to fail
+
 ### Changed
+
 ### Removed
+
 ### Deployment Changes
 
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->
+
 ## [0.0.0] - Project created

--- a/update_repos.py
+++ b/update_repos.py
@@ -386,7 +386,7 @@ def add_existing_github_check(existing_settings, new_settings, build_name):
 
 def update():
     if GITHUB_TOKEN == "":
-        raise "Invalid Github token"
+        raise ValueError("Invalid Github token")
 
     collaborators = [c.strip() for c in ALWAYS_COLLABORATORS.split(",") if c.strip()]
     print("ALWAYS_COLLABORATORS raw: '" + ALWAYS_COLLABORATORS + "'")

--- a/update_repos.py
+++ b/update_repos.py
@@ -366,11 +366,13 @@ def update_repo_actions_workflow_permissions(owner, name):
 
 
 def invite_collaborators(owner, name, collaborators):
+    print("Inviting collaborators to " + owner + "/" + name + ": " + str(collaborators))
     for collaborator in collaborators:
         try:
-            put_github("/repos/" + owner + "/" + name + "/collaborators/" + collaborator, {"permission": "push"})
-            print("Invited collaborator: " + collaborator)
+            result = put_github("/repos/" + owner + "/" + name + "/collaborators/" + collaborator, {"permission": "push"})
+            print("Invited collaborator: " + collaborator + " -> " + str(result))
         except Exception as e:
+            print("Failed to invite collaborator: " + collaborator)
             print(e)
             print("############################################################")
 
@@ -387,6 +389,8 @@ def update():
         raise "Invalid Github token"
 
     collaborators = [c.strip() for c in ALWAYS_COLLABORATORS.split(",") if c.strip()]
+    print("ALWAYS_COLLABORATORS raw: '" + ALWAYS_COLLABORATORS + "'")
+    print("Parsed collaborators: " + str(collaborators))
 
     repository_list_file = root / "personal/repos.lst"
     print(repository_list_file)


### PR DESCRIPTION
## Summary

- Fixes the root cause: the workflow was not passing `ALWAYS_COLLABORATORS` as an env var, so the script always saw an empty string and skipped all invites
- Adds `ALWAYS_COLLABORATORS: ${{ secrets.ALWAYS_COLLABORATORS }}` to the Update Repos step
- Logs the raw env var value and parsed list at startup so it's visible in run output
- Logs the API response (or failure reason) for each individual invite attempt
- Adds `.yamllint.yml` to accommodate pre-existing style in workflow files

## Test plan

- [ ] Set `ALWAYS_COLLABORATORS` secret in repo settings and trigger the workflow — check run logs show the parsed list and invite results

🤖 Generated with [Claude Code](https://claude.com/claude-code)