### PR TITLE
docs: Add .ai-instructions with env var workflow reminder

### DIFF
--- a/.ai-instructions
+++ b/.ai-instructions
@@ -1,0 +1,15 @@
+## Environment variables
+
+When adding a new `os.environ.get(...)` call to `update_repos.py` (or any other script in this repo), you **must** also add the corresponding `env:` entry to every workflow step that runs that script.
+
+For example, adding `FOO = os.environ.get("FOO", "")` in `update_repos.py` requires:
+
+```yaml
+- name: "Update Repos"
+  env:
+    SOURCE_PUSH_TOKEN: ${{ secrets.SOURCE_PUSH_TOKEN }}
+    FOO: ${{ secrets.FOO }}        # <-- add this
+  run: python update_repos.py
+```
+
+The relevant workflow is `.github/workflows/update_repo_settings.yml`. If the variable is not a secret (e.g. a plain config value) use `vars.FOO` instead of `secrets.FOO`.


### PR DESCRIPTION
Adds `.ai-instructions` reminding AI agents that any new `os.environ.get()` call in a script must also be added to the `env:` block of the corresponding workflow step. Prompted by the `ALWAYS_COLLABORATORS` variable being missed in #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)