### PR TITLE
chore: remove maintain-pr-description workflow from auto-deploy

### DIFF
--- a/personal/templates.json
+++ b/personal/templates.json
@@ -72,7 +72,8 @@
       ".github/workflows/reformat-yaml.yml": "Obsolete action",
       ".github/workflows/todos.yml": "Obsolete action",
       ".github/actions/build-check/actions.yml": "Obsolete action",
-      ".github/workflows/merge-dependabot.yml": "Replaced by approve-dependabot.yml native auto-merge"
+      ".github/workflows/merge-dependabot.yml": "Replaced by approve-dependabot.yml native auto-merge",
+      ".github/workflows/maintain-pr-description.yml": "Obsolete workflow"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/maintain-pr-description.yml` to the `cleanup.files` section of `personal/templates.json` so it is removed from all auto-deployed repositories.

Closes #423

## Test plan

- [ ] Verify `personal/templates.json` cleanup section contains the entry after merge.