### PR TITLE
chore: pin GitHub Actions uses: references to commit SHA

### DIFF
--- a/.github/workflows/build_personal_repos.yml
+++ b/.github/workflows/build_personal_repos.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repo"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{secrets.SOURCE_PUSH_TOKEN}}
 
       - name: "Set up Python"
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
 
@@ -42,7 +42,7 @@ jobs:
           cat README.md
 
       - name: "Commit and push if repos changed"
-        uses: stefanzweifel/git-auto-commit-action@v7.2.0
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Updated personal repos"
           file_pattern: "personal/repos.lst"

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: "Checkout Source"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
           cp funfair/templates.json "${{env.TARGET}}/funfair-templates.config"
 
       - name: "Deploy"
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_repo_settings.yml
+++ b/.github/workflows/update_repo_settings.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repo"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: "Set up Python"
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
+- TBD - to be finalized after review
 ### Added
 - Added .ai-instructions with reminder to wire new environment variables into workflow env blocks
 - Refactored Python scripts to use dependency injection and added pytest test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
-- TBD - to be finalized after review
+- Pinned GitHub Actions in workflows to immutable commit SHAs instead of mutable tags, preventing upstream tag repointing (accidental or malicious) from silently changing executed code
 ### Added
 - Added .ai-instructions with reminder to wire new environment variables into workflow env blocks
 - Refactored Python scripts to use dependency injection and added pytest test suite


### PR DESCRIPTION
## Summary
Pins `uses:` references in `.github/workflows/build_personal_repos.yml`, `.github/workflows/deploy-to-github-pages.yml`, and `.github/workflows/update_repo_settings.yml` from mutable tags to immutable commit SHAs, keeping the released version as a trailing comment. This prevents an upstream tag repoint (accidental or malicious) from silently changing the code executed by these workflows. Each SHA was independently verified against the upstream tag via `git ls-remote` before pinning.

Closes #439